### PR TITLE
fix: Empty username validation

### DIFF
--- a/__tests__/valid.test.ts
+++ b/__tests__/valid.test.ts
@@ -28,6 +28,13 @@ describe("UTILS - isValid", () => {
     expect(message).toStrictEqual(undefined);
   });
 
+  it("cannot use an empty username", async () => {
+    const { valid, message } = await isValid("");
+
+    expect(valid).toStrictEqual(false);
+    expect(message).toStrictEqual("Minimum length: 3 characters");
+  });
+
   it("cannot use a username of less than 3 characters", async () => {
     const { valid, message } = await isValid("a");
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -47,6 +47,14 @@ export const verifyMessage = (message: string, signature: string): string | unde
  * @returns {Promise<{ valid: boolean; message?: string }>}
  */
 export const isValid = async (username: string): Promise<{ valid: boolean; message?: string }> => {
+  // Check if the username is set to avoid unhandled rejection.
+  if (!username) {
+    return {
+      valid: false,
+      message: "Minimum length: 3 characters",
+    };
+  }
+
   // Cannot use a username of less than 3 characters
   if (username.length < 3) {
     return {


### PR DESCRIPTION
Edge condition caused by [api/users/valid.ts#L11](https://github.com/pancakeswap/pancake-profile-api/blob/develop/api/users/valid.ts#L11).